### PR TITLE
IoT registration script update to include a timestamp in the registration data.

### DIFF
--- a/scripts/one_time_key_creation_and_iot_device_registration.sh
+++ b/scripts/one_time_key_creation_and_iot_device_registration.sh
@@ -34,8 +34,11 @@ mac_addr = hex( uuid.getnode()).replace( '0x', '')
 mac = '-'.join( mac_addr[i : i + 2] for i in range( 0, 11, 2))
 print( '{}'.format( mac ))"`
 
+# Current UTC timestamp
+TIMESTAMP=`date --utc +%FT%TZ`
+
 # Must use " in JSON, hence the funny bash string concatenation for the data
-DATA='{"key": "'$KEY'", "cksum": "'$CKSUM'", "MAC": "'$MAC'"}'
+DATA='{"key": "'$KEY'", "cksum": "'$CKSUM'", "MAC": "'$MAC'", "timestamp": "'$TIMESTAMP'"}'
 
 # POST the data to the firebase cloud function
 RET=`curl --silent https://us-central1-fb-func-test.cloudfunctions.net/saveKey  -H "Content-Type: application/json" -X POST --data "$DATA"`
@@ -50,7 +53,7 @@ fi
 if [[ "$OSTYPE" == "linux"* ]]; then
   sudo -u postgres psql openag_brain -c "UPDATE app_iotconfigmodel set last_config_version = 0;"
 else # we are on OSX
-  psql postgres openag_brain -c "UPDATE app_iotconfigmodel set last_config_version = 1;"
+  psql postgres openag_brain -c "UPDATE app_iotconfigmodel set last_config_version = 0;"
 fi
 
 # Save this devices ID to a file that the brain startup script will read.


### PR DESCRIPTION
Add an optional timestamp field to the IoT registration data that is POSTed to the Firebase function and stored in the Firebase document collection.  Also fix OSX config version to match the one for BBB, even though we no longer use this value.

@jakerye I did this so in the admin UI I can see which IoT registrations are from what date.  If things are several days old, we can safely assume that the user is never going to complete that reg.  At least we will know when the reg happened.

I made the backend Firebase function validate the JSON schema 'timestamp' field as optional.  In a few months when all devices have been code updated and re-registered, I'll make the field mandatory.

@jakerye feel free to merge and delete this PR if you like.  Thanks!