### PR TITLE
a sudo prompt in the middle of a long install was causing an error to…

### DIFF
--- a/data/devices/smhc-air-v0.1.0.json
+++ b/data/devices/smhc-air-v0.1.0.json
@@ -1,0 +1,32 @@
+{   
+    "format": "openag-standard-v1",
+    "name": "SMHC Air v0.1.0",
+    "uuid": "601068b3-68ca-4a6d-8ff3-e11f5a44a1f5",
+    "peripherals": [
+        {
+            "name": "SHT25-Top",
+            "type": "SHT25",
+            "uuid": "23ed44ab-f810-4ca9-beab-82adcaf5f772",
+            "parameters": {
+                "setup": {
+                    "name": "SHT25 Temperature / Humidity Sensor",
+                    "file_name": "sht25/setups/default"
+                },
+                "variables": {
+                    "sensor": {
+                        "temperature_celsius": "air_temperature_celsius",
+                        "humidity_percent": "air_humidity_percent" 
+                    },
+                    "actuator": null
+                },
+                "communication": {
+                    "bus": "default", 
+                    "mux": "default", 
+                    "channel": 0, 
+                    "address": "0x40"
+                }
+            }
+        }
+    ],
+    "controllers": null
+}

--- a/install.sh
+++ b/install.sh
@@ -50,8 +50,13 @@ echo "Getting project root..."
 PROJECT_ROOT=`pwd`
 echo PROJECT_ROOT: $PROJECT_ROOT
 
+#debugrob, this causes us to fail since some of the scripts prompt for sudo
 # Stop installation on any error
-set -e
+#set -e
+
+# Just activate sudo here, so user doesn't have to install as root.
+echo "Using sudo to update your system, please provide your password now:"
+sudo date
 
 # Clean up before doing a full install
 sudo rm -fr $PROJECT_ROOT/venv

--- a/scripts/install/initialize_virtual_environment_activate.sh
+++ b/scripts/install/initialize_virtual_environment_activate.sh
@@ -47,3 +47,5 @@ echo "export RUNTIME_MODE=$RUNTIME_MODE" >> $PROJECT_ROOT/venv/bin/activate
 # Set platform environment variables in virtual environment
 printf "\n# Source project activate file\n" >> $PROJECT_ROOT/venv/bin/activate
 echo "source $PROJECT_ROOT/scripts/install/activate.sh" >> $PROJECT_ROOT/venv/bin/activate
+
+exit 0


### PR DESCRIPTION
… be returned which stops the install.sh script.  we need to clean up the install process and decide which user we install and run as.