### PR TITLE
Add an LED controlling API for demos (member's week, etc)

### DIFF
--- a/app/urls.py
+++ b/app/urls.py
@@ -51,6 +51,7 @@ router.register(r"system", views.SystemViewSet, base_name="api-system")
 router.register(r"network", views.NetworkViewSet, base_name="api-network")
 router.register(r"upgrade", views.UpgradeViewSet, base_name="api-upgrade")
 router.register(r"iot", views.IotViewSet, base_name="api-iot")
+router.register(r"led", views.LEDViewSet, base_name="api-led")
 
 # Initialize url pattern parameters
 login_settings = {"template_name": "login.html", "redirect_authenticated_user": True}

--- a/app/views.py
+++ b/app/views.py
@@ -1080,3 +1080,86 @@ def change_password(request: Request) -> render:
     else:
         form = PasswordChangeForm(request.user)
     return render(request, "accounts/change_password.html", {"form": form})
+
+
+# just for MW demo
+# ------------------------------------------------------------------------------
+class LEDViewSet(viewsets.ModelViewSet):
+    # Initialize logger
+    logger = logger.Logger("LEDViewSet", "app")
+
+    # --------------------------------------------------------------------------
+    def send_event(self, etype: str, value: str = None) -> Response:
+        v = ""
+        if value is not None and value is not "":
+            v = ',"value":"' + value + '"'
+
+        edict = {
+            "recipient": '{"type":"Peripheral","name":"LEDPanel-Top"}',
+            "request": '{"type":"' + etype + '"' + v + "}",
+        }
+
+        event_viewer = viewers.EventViewer()
+        message, status = event_viewer.create(edict)
+
+        response = {"message": message}
+        return Response(response, status=status)
+
+    # --------------------------------------------------------------------------
+    # Send LED peripheral the manual mode command
+    @list_route(methods=["POST"], permission_classes=[IsAuthenticated, IsAdminUser])
+    def manual(self, request: Request) -> Response:
+        self.logger.debug("Put LED in manual mode via REST API.")
+        return self.send_event(etype="Enable Manual Mode")
+
+    # --------------------------------------------------------------------------
+    # Send LED peripheral the reset event
+    @list_route(methods=["POST"], permission_classes=[IsAuthenticated, IsAdminUser])
+    def reset(self, request: Request) -> Response:
+        self.logger.debug("Reset LED.")
+        return self.send_event(etype="Reset")
+
+    # --------------------------------------------------------------------------
+    # Send LED peripheral the set channel event
+    @list_route(methods=["POST"], permission_classes=[IsAuthenticated, IsAdminUser])
+    def set_channel(self, request: Request) -> Response:
+
+        # Get parameters
+        try:
+            rdict = request.data
+        except Exception as e:
+            message = "Unable to create request dict: {}".format(e)
+            return Response(message, 400)
+        self.logger.debug("debubrob rdict={}".format(rdict))
+
+        channel = rdict.get("channel", "B")
+        percent = rdict.get("percent", "50")
+        self.logger.debug(
+            "Set LED channel via REST API, channel={}, percent={}".format(
+                channel, percent
+            )
+        )
+        # set channel event: B,50
+        val = "{},{}".format(channel, percent)
+        return self.send_event(etype="Set Channel", value=val)
+
+    # --------------------------------------------------------------------------
+    # Send LED peripheral the Turn On event
+    @list_route(methods=["POST"], permission_classes=[IsAuthenticated, IsAdminUser])
+    def turn_on(self, request: Request) -> Response:
+        self.logger.debug("Turn On LED.")
+        return self.send_event(etype="Turn On")
+
+    # --------------------------------------------------------------------------
+    # Send LED peripheral the Turn Off event
+    @list_route(methods=["POST"], permission_classes=[IsAuthenticated, IsAdminUser])
+    def turn_off(self, request: Request) -> Response:
+        self.logger.debug("Turn Off LED.")
+        return self.send_event(etype="Turn Off")
+
+    # --------------------------------------------------------------------------
+    # Send LED peripheral the fade event
+    @list_route(methods=["POST"], permission_classes=[IsAuthenticated, IsAdminUser])
+    def fade(self, request: Request) -> Response:
+        self.logger.debug("Fade LED.")
+        return self.send_event(etype="Fade")

--- a/device/peripherals/modules/actuator_grove_rgb_lcd/manager.py
+++ b/device/peripherals/modules/actuator_grove_rgb_lcd/manager.py
@@ -14,7 +14,7 @@ from device.peripherals.modules.actuator_grove_rgb_lcd import exceptions, events
 class ActuatorGroveRGBLCDManager(manager.PeripheralManager):
     """Manages an actuator controlled by a Grove RGB LCD."""
 
-    #--------------------------------------------------------------------------
+    # --------------------------------------------------------------------------
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initializes manager."""
 
@@ -28,9 +28,9 @@ class ActuatorGroveRGBLCDManager(manager.PeripheralManager):
         # Get setup defaults
         comms = {}
         if self.setup_dict is not None:
-            params = self.setup_dict.get('parameters')
+            params = self.setup_dict.get("parameters")
             if params is not None:
-                comms = params.get('communication')
+                comms = params.get("communication")
 
         # Try to get settings from setup file, if they are not in peripheral
         if self.rgb_address is None:
@@ -55,10 +55,12 @@ class ActuatorGroveRGBLCDManager(manager.PeripheralManager):
 
         if self.bus is None:
             self.bus = self.communication.get("bus")
-            self.bus = int(self.bus)
+            if self.bus is not None:
+                self.bus = int(self.bus)
         if self.mux is None:
             self.mux = self.communication.get("mux")
-            self.mux = int(self.mux, 16)
+            if self.mux is not None:
+                self.mux = int(self.mux, 16)
 
         self.logger.info(
             "rgb_address=0x{:02X}, lcd_address=0x{:02X}".format(
@@ -82,7 +84,7 @@ class ActuatorGroveRGBLCDManager(manager.PeripheralManager):
         self.heartbeat = 60  # seconds
         self.prev_update = 0  # timestamp
 
-    #--------------------------------------------------------------------------
+    # --------------------------------------------------------------------------
     def initialize_peripheral(self) -> None:
         """Initializes manager."""
         self.logger.info("Initializing")
@@ -108,7 +110,7 @@ class ActuatorGroveRGBLCDManager(manager.PeripheralManager):
             self.health = 0.0
             self.mode = modes.ERROR
 
-    #--------------------------------------------------------------------------
+    # --------------------------------------------------------------------------
     def setup_peripheral(self) -> None:
         """Sets up peripheral."""
         self.logger.debug("Setting up peripheral")
@@ -119,7 +121,7 @@ class ActuatorGroveRGBLCDManager(manager.PeripheralManager):
             self.mode = modes.ERROR
             self.health = 0.0
 
-    #--------------------------------------------------------------------------
+    # --------------------------------------------------------------------------
     def update_peripheral(self) -> None:
         """Updates peripheral by setting output to desired state."""
         try:
@@ -133,29 +135,31 @@ class ActuatorGroveRGBLCDManager(manager.PeripheralManager):
             self.mode = modes.ERROR
             self.health = 0.0
 
-    #--------------------------------------------------------------------------
+    # --------------------------------------------------------------------------
     def reset_peripheral(self) -> None:
         """Resets sensor."""
         self.logger.info("Resetting")
 
-    #--------------------------------------------------------------------------
+    # --------------------------------------------------------------------------
     def shutdown_peripheral(self) -> None:
         """Shutsdown peripheral."""
         self.logger.info("Shutting down")
 
     ##### HELPER FUNCTIONS ####################################################
 
-    #--------------------------------------------------------------------------
+    # --------------------------------------------------------------------------
     def set_output(self):
         """Gets desired output value from input sensor values."""
-        tempC = self.state.get_environment_reported_sensor_value(self.temperature_sensor)
+        tempC = self.state.get_environment_reported_sensor_value(
+            self.temperature_sensor
+        )
         hum = self.state.get_environment_reported_sensor_value(self.humidity_sensor)
         if tempC is None:
             return
 
         tempF = float(tempC) * 1.8 + 32.0
         lt = time.localtime()
-        lt = time.strftime( '%H:%M:%S', lt )
+        lt = time.strftime("%H:%M:%S", lt)
         output = "{}C / {}F\n{} %RH {}".format(tempC, tempF, hum, lt)
         self.logger.debug("Output: {}".format(output))
 
@@ -173,15 +177,15 @@ class ActuatorGroveRGBLCDManager(manager.PeripheralManager):
         self.driver.write_string(output)
         self.prev_update = time.time()
 
-    #--------------------------------------------------------------------------
+    # --------------------------------------------------------------------------
     def display_time(self):
         """Shows the current time."""
-        self.logger.debug('display time')
+        self.logger.debug("display time")
         self.driver.display_time()
 
     ##### EVENT FUNCTIONS #####################################################
 
-    #--------------------------------------------------------------------------
+    # --------------------------------------------------------------------------
     def create_peripheral_specific_event(
         self, request: Dict[str, Any]
     ) -> Tuple[str, int]:
@@ -191,7 +195,7 @@ class ActuatorGroveRGBLCDManager(manager.PeripheralManager):
         else:
             return "Unknown event request type", 400
 
-    #--------------------------------------------------------------------------
+    # --------------------------------------------------------------------------
     def check_peripheral_specific_events(self, request: Dict[str, Any]) -> None:
         """Checks peripheral specific events."""
         if request["type"] == events.DISPLAY_TIME:
@@ -200,7 +204,7 @@ class ActuatorGroveRGBLCDManager(manager.PeripheralManager):
             message = "Invalid event request type in queue: {}".format(request["type"])
             self.logger.error(message)
 
-    #--------------------------------------------------------------------------
+    # --------------------------------------------------------------------------
     def show_time(self) -> Tuple[str, int]:
         """Pre-processes display time event request."""
         self.logger.debug("Pre-processing display time event request")
@@ -216,7 +220,7 @@ class ActuatorGroveRGBLCDManager(manager.PeripheralManager):
         # Successful
         return "Displaying time", 200
 
-    #--------------------------------------------------------------------------
+    # --------------------------------------------------------------------------
     def _show_time(self) -> None:
         self.logger.debug("Processing display time event request")
 
@@ -234,4 +238,3 @@ class ActuatorGroveRGBLCDManager(manager.PeripheralManager):
             self.mode = modes.ERROR
             message = "Unable to display time, unhandled exception"
             self.logger.exception(message)
-

--- a/device/peripherals/modules/actuator_grove_rgb_lcd/simulator.py
+++ b/device/peripherals/modules/actuator_grove_rgb_lcd/simulator.py
@@ -8,7 +8,7 @@ from device.utilities.bitwise import byte_str
 from device.utilities.communication.i2c.peripheral_simulator import PeripheralSimulator
 
 # Import driver elements
-from device.peripherals.modules.actuator_grove_rgb_lcd import driver 
+from device.peripherals.modules.actuator_grove_rgb_lcd import driver
 
 
 class GroveRGBLCDSimulator(PeripheralSimulator):  # type: ignore
@@ -24,43 +24,46 @@ class GroveRGBLCDSimulator(PeripheralSimulator):  # type: ignore
         self.registers: Dict = {}
 
         # LCD commands
-        WRITE_BYTES = bytes([driver.GroveRGBLCDDriver.CMD, 
-                driver.GroveRGBLCDDriver.CLEAR])
+        WRITE_BYTES = bytes(
+            [driver.GroveRGBLCDDriver.CMD, driver.GroveRGBLCDDriver.CLEAR]
+        )
         RESPONSE_BYTES = bytes([0x00, 0x00])
-        self.writes = { byte_str(WRITE_BYTES): RESPONSE_BYTES }
-        
-        WRITE_BYTES = bytes([driver.GroveRGBLCDDriver.CMD, 
-                driver.GroveRGBLCDDriver.DISPLAY_ON_NO_CURSOR])
-        self.writes[byte_str(WRITE_BYTES)] = RESPONSE_BYTES 
+        self.writes = {byte_str(WRITE_BYTES): RESPONSE_BYTES}
 
-        WRITE_BYTES = bytes([driver.GroveRGBLCDDriver.CMD, 
-                driver.GroveRGBLCDDriver.TWO_LINES])
-        self.writes[byte_str(WRITE_BYTES)] = RESPONSE_BYTES 
+        WRITE_BYTES = bytes(
+            [
+                driver.GroveRGBLCDDriver.CMD,
+                driver.GroveRGBLCDDriver.DISPLAY_ON_NO_CURSOR,
+            ]
+        )
+        self.writes[byte_str(WRITE_BYTES)] = RESPONSE_BYTES
 
-        WRITE_BYTES = bytes([driver.GroveRGBLCDDriver.CMD, 
-                driver.GroveRGBLCDDriver.NEWLINE])
-        self.writes[byte_str(WRITE_BYTES)] = RESPONSE_BYTES 
+        WRITE_BYTES = bytes(
+            [driver.GroveRGBLCDDriver.CMD, driver.GroveRGBLCDDriver.TWO_LINES]
+        )
+        self.writes[byte_str(WRITE_BYTES)] = RESPONSE_BYTES
+
+        WRITE_BYTES = bytes(
+            [driver.GroveRGBLCDDriver.CMD, driver.GroveRGBLCDDriver.NEWLINE]
+        )
+        self.writes[byte_str(WRITE_BYTES)] = RESPONSE_BYTES
 
         # RGB commands
         WRITE_BYTES = bytes([0, 0])
-        self.writes[byte_str(WRITE_BYTES)] = RESPONSE_BYTES 
+        self.writes[byte_str(WRITE_BYTES)] = RESPONSE_BYTES
         WRITE_BYTES = bytes([1, 0])
-        self.writes[byte_str(WRITE_BYTES)] = RESPONSE_BYTES 
+        self.writes[byte_str(WRITE_BYTES)] = RESPONSE_BYTES
         WRITE_BYTES = bytes([0x08, 0xAA])
-        self.writes[byte_str(WRITE_BYTES)] = RESPONSE_BYTES 
+        self.writes[byte_str(WRITE_BYTES)] = RESPONSE_BYTES
         WRITE_BYTES = bytes([4, 0])
-        self.writes[byte_str(WRITE_BYTES)] = RESPONSE_BYTES 
+        self.writes[byte_str(WRITE_BYTES)] = RESPONSE_BYTES
         WRITE_BYTES = bytes([4, 0xFF])
-        self.writes[byte_str(WRITE_BYTES)] = RESPONSE_BYTES 
+        self.writes[byte_str(WRITE_BYTES)] = RESPONSE_BYTES
         WRITE_BYTES = bytes([3, 0])
-        self.writes[byte_str(WRITE_BYTES)] = RESPONSE_BYTES 
+        self.writes[byte_str(WRITE_BYTES)] = RESPONSE_BYTES
         WRITE_BYTES = bytes([3, 0xFF])
-        self.writes[byte_str(WRITE_BYTES)] = RESPONSE_BYTES 
+        self.writes[byte_str(WRITE_BYTES)] = RESPONSE_BYTES
         WRITE_BYTES = bytes([2, 0])
-        self.writes[byte_str(WRITE_BYTES)] = RESPONSE_BYTES 
+        self.writes[byte_str(WRITE_BYTES)] = RESPONSE_BYTES
         WRITE_BYTES = bytes([2, 0xFF])
-        self.writes[byte_str(WRITE_BYTES)] = RESPONSE_BYTES 
-
-
-
-
+        self.writes[byte_str(WRITE_BYTES)] = RESPONSE_BYTES

--- a/device/peripherals/modules/actuator_grove_rgb_lcd/tests/test_lcd_manager.py
+++ b/device/peripherals/modules/actuator_grove_rgb_lcd/tests/test_lcd_manager.py
@@ -1,5 +1,5 @@
 # To run a single test:
-# . ~/openag-device-software/venv/bin/activate
+# source ~/openag-device-software/venv/bin/activate
 # pytest -s -k "test_init" test_lcd_manager.py
 
 
@@ -17,7 +17,9 @@ from device.utilities.communication.i2c.mux_simulator import MuxSimulator
 from device.utilities.state.main import State
 
 # Import peripheral manager
-from device.peripherals.modules.actuator_grove_rgb_lcd.manager import ActuatorGroveRGBLCDManager
+from device.peripherals.modules.actuator_grove_rgb_lcd.manager import (
+    ActuatorGroveRGBLCDManager,
+)
 
 # Load test config
 PERIPHERAL_NAME = "LCD"
@@ -25,7 +27,9 @@ CONFIG_PATH = (
     ROOT_DIR + "/device/peripherals/modules/actuator_grove_rgb_lcd/tests/config.json"
 )
 device_config = json.load(open(CONFIG_PATH))
-peripheral_config = accessors.get_peripheral_config(device_config["peripherals"], PERIPHERAL_NAME)
+peripheral_config = accessors.get_peripheral_config(
+    device_config["peripherals"], PERIPHERAL_NAME
+)
 
 
 def test_init() -> None:

--- a/scripts/database/create_database.sh
+++ b/scripts/database/create_database.sh
@@ -9,7 +9,7 @@ if [[ "$OSTYPE" == "linux"* ]]; then
 
 # Create database on darwin operating system 
 elif [[ "$OSTYPE" == "darwin"* ]]; then
-    psql postgres -c "CREATE DATABASE openag_brain OWNER openag;"
+    psql --dbname=postgres --username=openag -c "CREATE DATABASE openag_brain OWNER openag;"
 
 # Unsupported operating system
 else

--- a/scripts/database/create_postgres_user.sh
+++ b/scripts/database/create_postgres_user.sh
@@ -10,8 +10,8 @@ if [[ "$OSTYPE" == "linux"* ]]; then
 
 # Create database on darwin operating system 
 elif [[ "$OSTYPE" == "darwin"* ]]; then
-    psql postgres -c "CREATE USER openag WITH PASSWORD 'openag';"
-    psql postgres -c "ALTER USER openag SUPERUSER;"
+    psql --dbname=postgres --username=openag -c "CREATE USER openag WITH PASSWORD 'openag';"
+    psql --dbname=postgres --username=openag -c "ALTER USER openag SUPERUSER;"
 
 # Unsupported operating system
 else

--- a/scripts/database/drop_database.sh
+++ b/scripts/database/drop_database.sh
@@ -9,7 +9,7 @@ if [[ "$OSTYPE" == "linux"* ]]; then
 
 # Recreate on darwin operating system
 elif [[ "$OSTYPE" == "darwin"* ]]; then
-  psql postgres -c "DROP DATABASE openag_brain;"
+  psql --dbname=postgres --username=openag -c "DROP DATABASE openag_brain;"
 
 # Invalid operating system
 else

--- a/scripts/database/drop_postgres_user.sh
+++ b/scripts/database/drop_postgres_user.sh
@@ -9,7 +9,7 @@ if [[ "$OSTYPE" == "linux"* ]]; then
 
 # Create database on darwin operating system 
 elif [[ "$OSTYPE" == "darwin"* ]]; then
-    psql postgres -c "DROP USER openag;"
+    psql --dbname=postgres --username=openag -c "DROP USER openag;"
 
 # Unsupported operating system
 else

--- a/scripts/database/drop_state_table.sh
+++ b/scripts/database/drop_state_table.sh
@@ -8,8 +8,8 @@ if [[ "$OSTYPE" == "linux"* ]]; then
   sudo -u postgres psql openag_brain -c "DELETE FROM app_statemodel;"
 
 # Drop state table on darwin operating system
-elif [[ "$OSTYPE" == "linux"* ]]; then
-  psql postgres openag_brain -c "DELETE FROM app_statemodel;"
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+  psql --dbname=postgres --username=openag openag_brain -c "DELETE FROM app_statemodel;"
 
 # Invalid operating system
 else

--- a/scripts/database/list_databases.sh
+++ b/scripts/database/list_databases.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-psql --username=openag openag_brain -c '\l'
+psql --dbname=openag_brain --username=openag -c '\l'

--- a/scripts/database/list_tables.sh
+++ b/scripts/database/list_tables.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-psql --username=openag openag_brain -c '\dt'
+psql --username=openag --dbname=openag_brain -c '\dt'

--- a/scripts/demo/api_test.sh
+++ b/scripts/demo/api_test.sh
@@ -1,0 +1,87 @@
+#/bin/bash
+
+HOST=localhost
+HOST=192.168.1.11
+
+LOGIN_URL=http://$HOST/accounts/login/?next=/
+YOUR_USER='openag'
+YOUR_PASS='openag'
+COOKIES=cookies.txt
+CURL_BIN="curl -s -c $COOKIES -b $COOKIES -e $LOGIN_URL"
+
+# saves the cookies.txt file
+$CURL_BIN $LOGIN_URL > /dev/null
+
+# get the token from the file:
+#   grep the line in the file that has the token,
+#   reverse all the chars in the line to put the token as the first word,
+#   cut the first field from the tab separated line,
+#   un-reverse the chars in the token
+CSRF=`grep csrftoken $COOKIES | rev | cut -f 1 | rev`
+DJANGO_TOKEN="csrfmiddlewaretoken=$CSRF"
+
+# perform login 
+$CURL_BIN \
+    -d "$DJANGO_TOKEN&username=$YOUR_USER&password=$YOUR_PASS" \
+    -X POST $LOGIN_URL
+
+# put LED peripheral in manual mode
+REST_URL=http://$HOST/api/led/manual/
+REST_METHOD=POST
+POST_DATA='{}'
+echo "CALLING REST API: $REST_URL"
+RET=`$CURL_BIN -X $REST_METHOD $REST_URL -H "X-CSRFToken: $CSRF" -H "Content-Type: application/json" -d "$POST_DATA"`
+echo $RET
+sleep 2
+echo ''
+
+# turn LED off
+REST_URL=http://$HOST/api/led/turn_off/
+REST_METHOD=POST
+POST_DATA=''
+echo "CALLING REST API: $REST_URL"
+RET=`$CURL_BIN -X $REST_METHOD $REST_URL -H "X-CSRFToken: $CSRF" -H "Content-Type: application/json" -d "$POST_DATA"`
+echo $RET
+sleep 2
+echo ''
+
+# set LED peripheral channel to blue
+REST_URL=http://$HOST/api/led/set_channel/
+REST_METHOD=POST
+POST_DATA='{"channel":"B","percent":"50"}'
+echo "CALLING REST API: $REST_URL"
+RET=`$CURL_BIN -X $REST_METHOD $REST_URL -H "X-CSRFToken: $CSRF" -H "Content-Type: application/json" -d "$POST_DATA"`
+echo $RET
+sleep 2
+echo ''
+
+# fade LED 
+REST_URL=http://$HOST/api/led/fade/
+REST_METHOD=POST
+POST_DATA=''
+echo "CALLING REST API: $REST_URL"
+RET=`$CURL_BIN -X $REST_METHOD $REST_URL -H "X-CSRFToken: $CSRF" -H "Content-Type: application/json" -d "$POST_DATA"`
+echo $RET
+echo 'sleeping for 30 secs while fading'
+sleep 30
+echo ''
+
+# reset LED peripheral 
+REST_URL=http://$HOST/api/led/reset/
+REST_METHOD=POST
+POST_DATA=''
+echo "CALLING REST API: $REST_URL"
+RET=`$CURL_BIN -X $REST_METHOD $REST_URL -H "X-CSRFToken: $CSRF" -H "Content-Type: application/json" -d "$POST_DATA"`
+echo $RET
+echo ''
+
+# logout
+#rm $COOKIES
+
+
+# use with GET
+#REST_METHOD=GET
+#REST_URL=http://$HOST/api/iot/info/
+#REST_URL=http://$HOST/api/state/
+#REST_URL=http://$HOST/api/
+


### PR DESCRIPTION
also fix LCD code tests
update the database scripts to work on OSX

For the upcoming member's week Apr. 2019 we will use the code on the pfc3-rack-20-test branch which has this same code.   But I also added it to master since it won't cause problems and we will need it in the future for demos.  It is still a secured API and uses the existing event system, so nothing hacky.