### PR TITLE
add CORS headers

### DIFF
--- a/app/settings.py
+++ b/app/settings.py
@@ -44,9 +44,11 @@ INSTALLED_APPS = [
     "device.resource",
     "device.network",
     "device.upgrade",
+    "corsheaders",
 ]
 
 MIDDLEWARE = [
+    "corsheaders.middleware.CorsMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
@@ -56,6 +58,12 @@ MIDDLEWARE = [
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
 ]
+
+# Allow all cross origin requests.  
+# Required to call our REST API from a browser.
+# https://github.com/ottoyiu/django-cors-headers/#configuration
+CORS_ORIGIN_ALLOW_ALL = True
+CORS_ALLOW_CREDENTIALS = True
 
 # Configure static file storage
 STATIC_URL = "/app/static/"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Django==1.11.20
 pytest-cov==2.5.1
 mypy==0.600
-
+django-cors-headers==2.5.2
 djangorestframework==3.7.3
 jsonschema==2.6.0
 numpy==1.14.3


### PR DESCRIPTION
This will allow us to call the REST API we implement in Django from another browser, like the member's week demo I'm setting up.